### PR TITLE
Complete docker compose variable interpolation

### DIFF
--- a/config/env.go
+++ b/config/env.go
@@ -1,0 +1,156 @@
+package config
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// EnvironmentManager handles environment variables and .env file parsing
+type EnvironmentManager struct {
+	envVars map[string]string
+}
+
+// NewEnvironmentManager creates a new environment manager
+func NewEnvironmentManager() *EnvironmentManager {
+	return &EnvironmentManager{
+		envVars: make(map[string]string),
+	}
+}
+
+// LoadEnvironmentFromFile loads variables from a .env file
+func (em *EnvironmentManager) LoadEnvironmentFromFile(envFilePath string) error {
+	if envFilePath == "" {
+		return nil
+	}
+
+	if !filepath.IsAbs(envFilePath) {
+		wd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get working directory: %w", err)
+		}
+		envFilePath = filepath.Join(wd, envFilePath)
+	}
+
+	if _, err := os.Stat(envFilePath); os.IsNotExist(err) {
+		return fmt.Errorf("env file not found: %s", envFilePath)
+	}
+
+	file, err := os.Open(envFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to open env file: %w", err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		
+		// Skip empty lines and comments
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		// Parse KEY=VALUE format
+		if err := em.parseEnvLine(line, lineNum); err != nil {
+			return fmt.Errorf("error parsing line %d in %s: %w", lineNum, envFilePath, err)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading env file: %w", err)
+	}
+
+	return nil
+}
+
+// LoadSystemEnvironment loads variables from the system environment
+func (em *EnvironmentManager) LoadSystemEnvironment() {
+	for _, env := range os.Environ() {
+		parts := strings.SplitN(env, "=", 2)
+		if len(parts) == 2 {
+			em.envVars[parts[0]] = parts[1]
+		}
+	}
+}
+
+// parseEnvLine parses a single line from the .env file
+func (em *EnvironmentManager) parseEnvLine(line string, lineNum int) error {
+	// Basic KEY=VALUE parsing
+	parts := strings.SplitN(line, "=", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid format, expected KEY=VALUE")
+	}
+
+	key := strings.TrimSpace(parts[0])
+	value := strings.TrimSpace(parts[1])
+
+	// Validate key format (basic validation)
+	if key == "" {
+		return fmt.Errorf("empty key")
+	}
+
+	// Remove quotes from value if present
+	if len(value) >= 2 {
+		if (strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"")) ||
+			(strings.HasPrefix(value, "'") && strings.HasSuffix(value, "'")) {
+			value = value[1 : len(value)-1]
+		}
+	}
+
+	em.envVars[key] = value
+	return nil
+}
+
+// InterpolateString performs variable interpolation on a string using ${VAR} syntax
+func (em *EnvironmentManager) InterpolateString(input string) string {
+	// Regex to match ${VAR} patterns
+	re := regexp.MustCompile(`\$\{([^}]+)\}`)
+	
+	return re.ReplaceAllStringFunc(input, func(match string) string {
+		// Extract variable name from ${VAR}
+		varName := match[2 : len(match)-1] // Remove ${ and }
+		
+		// Look up the variable value
+		if value, exists := em.envVars[varName]; exists {
+			return value
+		}
+		
+		// If variable not found, return the original match
+		return match
+	})
+}
+
+// InterpolateMapValues performs variable interpolation on all string values in a map
+func (em *EnvironmentManager) InterpolateMapValues(m map[string]string) map[string]string {
+	result := make(map[string]string)
+	for key, value := range m {
+		result[key] = em.InterpolateString(value)
+	}
+	return result
+}
+
+// GetVariable returns the value of an environment variable
+func (em *EnvironmentManager) GetVariable(name string) (string, bool) {
+	value, exists := em.envVars[name]
+	return value, exists
+}
+
+// SetVariable sets an environment variable
+func (em *EnvironmentManager) SetVariable(name, value string) {
+	em.envVars[name] = value
+}
+
+// GetAllVariables returns a copy of all environment variables
+func (em *EnvironmentManager) GetAllVariables() map[string]string {
+	result := make(map[string]string)
+	for k, v := range em.envVars {
+		result[k] = v
+	}
+	return result
+}

--- a/config/env_test.go
+++ b/config/env_test.go
@@ -1,0 +1,257 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewEnvironmentManager(t *testing.T) {
+	em := NewEnvironmentManager()
+	if em == nil {
+		t.Fatal("NewEnvironmentManager returned nil")
+	}
+	if em.envVars == nil {
+		t.Fatal("envVars map not initialized")
+	}
+}
+
+func TestLoadEnvironmentFromFile(t *testing.T) {
+	// Create a temporary directory
+	tempDir, err := os.MkdirTemp("", "env_test")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	// Create a test .env file
+	envFile := filepath.Join(tempDir, ".env")
+	envContent := `# Test environment file
+TAG=v1.5
+PROJECT_NAME=test-project
+AUTHOR=john-doe
+# Empty line above
+
+QUOTED_VALUE="quoted value"
+SINGLE_QUOTED='single quoted'
+NO_QUOTES=no quotes value
+`
+	err = os.WriteFile(envFile, []byte(envContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write env file: %v", err)
+	}
+
+	// Test loading the file
+	em := NewEnvironmentManager()
+	err = em.LoadEnvironmentFromFile(envFile)
+	if err != nil {
+		t.Fatalf("LoadEnvironmentFromFile failed: %v", err)
+	}
+
+	// Verify variables were loaded correctly
+	tests := []struct {
+		key      string
+		expected string
+	}{
+		{"TAG", "v1.5"},
+		{"PROJECT_NAME", "test-project"},
+		{"AUTHOR", "john-doe"},
+		{"QUOTED_VALUE", "quoted value"},
+		{"SINGLE_QUOTED", "single quoted"},
+		{"NO_QUOTES", "no quotes value"},
+	}
+
+	for _, test := range tests {
+		value, exists := em.GetVariable(test.key)
+		if !exists {
+			t.Errorf("Variable %s not found", test.key)
+			continue
+		}
+		if value != test.expected {
+			t.Errorf("Variable %s: expected %q, got %q", test.key, test.expected, value)
+		}
+	}
+}
+
+func TestLoadEnvironmentFromFileNotFound(t *testing.T) {
+	em := NewEnvironmentManager()
+	err := em.LoadEnvironmentFromFile("/nonexistent/file.env")
+	if err == nil {
+		t.Fatal("Expected error for nonexistent file")
+	}
+}
+
+func TestLoadEnvironmentFromFileEmpty(t *testing.T) {
+	em := NewEnvironmentManager()
+	err := em.LoadEnvironmentFromFile("")
+	if err != nil {
+		t.Fatalf("Empty path should not cause error: %v", err)
+	}
+}
+
+func TestLoadSystemEnvironment(t *testing.T) {
+	// Set a test environment variable
+	testKey := "TEST_ENV_VAR_FOR_TESTING"
+	testValue := "test_value_123"
+	err := os.Setenv(testKey, testValue)
+	if err != nil {
+		t.Fatalf("Failed to set test env var: %v", err)
+	}
+	defer os.Unsetenv(testKey)
+
+	em := NewEnvironmentManager()
+	em.LoadSystemEnvironment()
+
+	value, exists := em.GetVariable(testKey)
+	if !exists {
+		t.Errorf("System environment variable %s not loaded", testKey)
+	}
+	if value != testValue {
+		t.Errorf("System environment variable %s: expected %q, got %q", testKey, testValue, value)
+	}
+}
+
+func TestParseEnvLine(t *testing.T) {
+	em := NewEnvironmentManager()
+
+	tests := []struct {
+		line        string
+		expectError bool
+		key         string
+		value       string
+	}{
+		{"KEY=value", false, "KEY", "value"},
+		{"KEY=", false, "KEY", ""},
+		{"KEY=value with spaces", false, "KEY", "value with spaces"},
+		{"KEY=\"quoted value\"", false, "KEY", "quoted value"},
+		{"KEY='single quoted'", false, "KEY", "single quoted"},
+		{"  KEY  =  value  ", false, "KEY", "value"},
+		{"=value", true, "", ""},
+		{"KEY", true, "", ""},
+		{"", true, "", ""},
+	}
+
+	for i, test := range tests {
+		err := em.parseEnvLine(test.line, i+1)
+		if test.expectError {
+			if err == nil {
+				t.Errorf("Line %d: expected error for %q", i+1, test.line)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Line %d: unexpected error for %q: %v", i+1, test.line, err)
+			continue
+		}
+
+		value, exists := em.GetVariable(test.key)
+		if !exists {
+			t.Errorf("Line %d: variable %s not found after parsing %q", i+1, test.key, test.line)
+			continue
+		}
+		if value != test.value {
+			t.Errorf("Line %d: variable %s: expected %q, got %q", i+1, test.key, test.value, value)
+		}
+	}
+}
+
+func TestInterpolateString(t *testing.T) {
+	em := NewEnvironmentManager()
+	em.SetVariable("TAG", "v1.5")
+	em.SetVariable("PROJECT", "my-project")
+	em.SetVariable("EMPTY", "")
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"simple string", "simple string"},
+		{"${TAG}", "v1.5"},
+		{"version:${TAG}", "version:v1.5"},
+		{"${PROJECT}-${TAG}", "my-project-v1.5"},
+		{"${NONEXISTENT}", "${NONEXISTENT}"},
+		{"${TAG}/${PROJECT}", "v1.5/my-project"},
+		{"${EMPTY}", ""},
+		{"pre-${TAG}-post", "pre-v1.5-post"},
+		{"multiple: ${TAG} and ${PROJECT}", "multiple: v1.5 and my-project"},
+	}
+
+	for _, test := range tests {
+		result := em.InterpolateString(test.input)
+		if result != test.expected {
+			t.Errorf("InterpolateString(%q): expected %q, got %q", test.input, test.expected, result)
+		}
+	}
+}
+
+func TestInterpolateMapValues(t *testing.T) {
+	em := NewEnvironmentManager()
+	em.SetVariable("TAG", "v1.5")
+	em.SetVariable("PROJECT", "my-project")
+
+	input := map[string]string{
+		"version":     "${TAG}",
+		"name":        "${PROJECT}",
+		"description": "Project ${PROJECT} version ${TAG}",
+		"static":      "no variables here",
+	}
+
+	expected := map[string]string{
+		"version":     "v1.5",
+		"name":        "my-project",
+		"description": "Project my-project version v1.5",
+		"static":      "no variables here",
+	}
+
+	result := em.InterpolateMapValues(input)
+
+	for key, expectedValue := range expected {
+		if result[key] != expectedValue {
+			t.Errorf("InterpolateMapValues: key %s: expected %q, got %q", key, expectedValue, result[key])
+		}
+	}
+}
+
+func TestGetSetVariable(t *testing.T) {
+	em := NewEnvironmentManager()
+
+	// Test setting and getting
+	em.SetVariable("TEST_KEY", "test_value")
+	value, exists := em.GetVariable("TEST_KEY")
+	if !exists {
+		t.Error("Variable should exist after setting")
+	}
+	if value != "test_value" {
+		t.Errorf("Expected %q, got %q", "test_value", value)
+	}
+
+	// Test nonexistent variable
+	_, exists = em.GetVariable("NONEXISTENT")
+	if exists {
+		t.Error("Nonexistent variable should not exist")
+	}
+}
+
+func TestGetAllVariables(t *testing.T) {
+	em := NewEnvironmentManager()
+	em.SetVariable("KEY1", "value1")
+	em.SetVariable("KEY2", "value2")
+
+	all := em.GetAllVariables()
+	if len(all) != 2 {
+		t.Errorf("Expected 2 variables, got %d", len(all))
+	}
+	if all["KEY1"] != "value1" {
+		t.Errorf("KEY1: expected %q, got %q", "value1", all["KEY1"])
+	}
+	if all["KEY2"] != "value2" {
+		t.Errorf("KEY2: expected %q, got %q", "value2", all["KEY2"])
+	}
+
+	// Verify it's a copy (modifying the returned map shouldn't affect the original)
+	all["KEY1"] = "modified"
+	originalValue, _ := em.GetVariable("KEY1")
+	if originalValue != "value1" {
+		t.Error("GetAllVariables should return a copy, not the original map")
+	}
+}

--- a/config/loader.go
+++ b/config/loader.go
@@ -8,6 +8,10 @@ import (
 )
 
 func LoadConfig(filepath string) (*ComposeConfig, error) {
+	return LoadConfigWithEnvironment(filepath, nil)
+}
+
+func LoadConfigWithEnvironment(filepath string, envManager *EnvironmentManager) (*ComposeConfig, error) {
 	if _, err := os.Stat(filepath); os.IsNotExist(err) {
 		return nil, fmt.Errorf("config file not found: %s", filepath)
 	}
@@ -15,6 +19,12 @@ func LoadConfig(filepath string) (*ComposeConfig, error) {
 	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	// Perform environment variable interpolation on the raw YAML content if envManager is provided
+	if envManager != nil {
+		interpolatedData := envManager.InterpolateString(string(data))
+		data = []byte(interpolatedData)
 	}
 
 	var config ComposeConfig

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var (
 	dryRun          = flag.Bool("dry-run", false, "Show what would be executed without running")
 	boilerplatePath = flag.String("boilerplate-path", "", "Path to boilerplate CLI (defaults to PATH lookup)")
 	verbose         = flag.Bool("verbose", false, "Show detailed output from boilerplate commands")
+	envFile         = flag.String("env-file", "", "Path to .env file (defaults to .env in current directory)")
 )
 
 func main() {
@@ -42,7 +43,21 @@ func main() {
 		log.Fatal("No compose file found. Use -f to specify a file.")
 	}
 
-	cfg, err := config.LoadConfig(configPath)
+	// Set up environment manager
+	envManager := config.NewEnvironmentManager()
+	
+	// Load system environment first
+	envManager.LoadSystemEnvironment()
+	
+	// Load from .env file if specified or if default .env exists
+	envFilePath := findEnvFile(*envFile)
+	if envFilePath != "" {
+		if err := envManager.LoadEnvironmentFromFile(envFilePath); err != nil {
+			log.Fatalf("Failed to load environment file: %v", err)
+		}
+	}
+
+	cfg, err := config.LoadConfigWithEnvironment(configPath, envManager)
 	if err != nil {
 		log.Fatalf("Failed to load config: %v", err)
 	}
@@ -77,6 +92,19 @@ func findConfigFile(specified string) string {
 	return ""
 }
 
+func findEnvFile(specified string) string {
+	if specified != "" {
+		return specified
+	}
+
+	// Check for default .env file
+	if _, err := os.Stat(".env"); err == nil {
+		return ".env"
+	}
+
+	return ""
+}
+
 func printUsage() {
 	fmt.Println("boilerplate-compose - Orchestrate template rendering using boilerplate CLI")
 	fmt.Println("\nUsage:")
@@ -86,4 +114,5 @@ func printUsage() {
 	fmt.Println("\nExample:")
 	fmt.Println("  boilerplate-compose -f my-compose.yaml -verbose")
 	fmt.Println("  boilerplate-compose -dry-run")
+	fmt.Println("  boilerplate-compose --env-file production.env")
 }


### PR DESCRIPTION
Add support for Docker Compose-style variable interpolation using `${VAR}` syntax and `.env` files.

---
<a href="https://cursor.com/background-agent?bcId=bc-ad406c7b-2055-42d6-bbd0-bea6e07a63f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ad406c7b-2055-42d6-bbd0-bea6e07a63f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

