### PR TITLE
Test justfile variable interpolation with .env

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,9 +15,13 @@ test-compose:
 test-complex:
     go run . -f tests/complex-test.yaml
 
+# Test variable interpolation using .env file in tests directory
+test-env:
+    go run . -f tests/interpolation-test.yaml -env-file tests/.env -dry-run
+
 # Clean output directory
 clean:
     rm -rf tests/output/*
 
 # Run all tests and clean up
-test-all: test-basic test-compose test-complex clean
+test-all: test-basic test-compose test-complex test-env clean

--- a/tests/interpolation-test.yaml
+++ b/tests/interpolation-test.yaml
@@ -1,0 +1,11 @@
+version: "1.0"
+
+templates:
+  env-website:
+    template-url: "${TEMPLATE_URL}"
+    output-folder: "./output/${OUTPUT_SUBDIR}"
+    non-interactive: true
+    vars:
+      Title: "${TITLE}"
+      WelcomeText: "${WELCOME}"
+      ShowLogo: "${SHOW_LOGO}"


### PR DESCRIPTION
Add a new test recipe to `justfile` to verify variable interpolation using a `.env` file.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7a8e5b3-de75-4aa6-a12d-b7400ca7279d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7a8e5b3-de75-4aa6-a12d-b7400ca7279d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

