### PR TITLE
Configure renovate for test directory updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,20 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Renovate
+        uses: renovatebot/github-action@v40.3.1
+        with:
+          configurationFile: renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN }}
+        env:
+          LOG_LEVEL: debug

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "jsonata",
+      "fileMatch": ["^tests/.*\\.ya?ml$"],
+      "fileFormat": "yaml",
+      "jsonata": "$each(templates, function($tpl, $tplName) { $url := $tpl.\"template-url\"; $isGh := $url and $contains($url, \"github.com\") and $contains($url, \"ref=\"); $repoPart := $isGh ? ($contains($url, \"github.com:\") ? $split($url, \"github.com:\")[1] : $split($url, \"github.com/\")[1]) : null; $repo := $repoPart ? $split($repoPart, \".git\")[0] : null; $ref := $isGh ? $split($split($url, \"ref=\")[1], \"&\")[0] : null; $refSegment := $isGh ? (\"ref=\" & $ref) : null; $isGh and $repo and $ref ? { \"depName\": $repo, \"currentValue\": $ref, \"replaceString\": $refSegment, \"templateName\": $tplName, \"depType\": \"template-\" & $tplName } : null })",
+      "datasourceTemplate": "github-tags",
+      "autoReplaceStringTemplate": "ref={{newValue}}"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["custom.jsonata"],
+      "additionalBranchPrefix": "{{depType}}-",
+      "commitMessageSuffix": "({{depType}})",
+      "separateMinorPatch": true
+    }
+  ]
+}

--- a/tests/boilerplate-v081-tests.yaml
+++ b/tests/boilerplate-v081-tests.yaml
@@ -1,0 +1,20 @@
+version: "1.0"
+
+templates:
+  website-ssh:
+    template-url: "git@github.com:gruntwork-io/boilerplate.git//examples/for-learning-and-testing/website?ref=v0.8.1"
+    output-folder: "./output/website-ssh-v081"
+    non-interactive: true
+    vars:
+      Title: "Website SSH v0.8.1"
+      WelcomeText: "Testing v0.8.1 via SSH"
+      ShowLogo: "true"
+
+  website-https:
+    template-url: "https://github.com/gruntwork-io/boilerplate.git//examples/for-learning-and-testing/website?ref=v0.8.1"
+    output-folder: "./output/website-https-v081"
+    non-interactive: true
+    vars:
+      Title: "Website HTTPS v0.8.1"
+      WelcomeText: "Testing v0.8.1 via HTTPS"
+      ShowLogo: "false"


### PR DESCRIPTION
Add Renovate to automate updates for GitHub template references in test files, ensuring separate PRs for each template.

---
<a href="https://cursor.com/background-agent?bcId=bc-a165712c-5a62-41c5-8f59-72a2e02c8473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a165712c-5a62-41c5-8f59-72a2e02c8473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

